### PR TITLE
Updated pyproject.toml to include git repo

### DIFF
--- a/crates/aoe2rec-py/pyproject.toml
+++ b/crates/aoe2rec-py/pyproject.toml
@@ -12,6 +12,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = ["pip>=24.3.1"]
+
+[project.urls]
+Homepage = "https://github.com/aoe2ct/aoe2rec"
+Repository = "https://github.com/aoe2ct/aoe2rec/tree/main/crates/aoe2rec-py"
+
 [tool.maturin]
 features = ["pyo3/extension-module"]
 python-source = "python"


### PR DESCRIPTION
This should add a URL to the repo on this page

![image](https://github.com/user-attachments/assets/9d754d94-0c93-479d-9508-eebb1f93bf52)

That way no one else needs to wonder where the heck the source is